### PR TITLE
Cambio de nombre de interfaz Idefensa

### DIFF
--- a/src/Library/Items/IAttack.cs
+++ b/src/Library/Items/IAttack.cs
@@ -1,7 +1,7 @@
 namespace RoleplayGame
 {
     // Interfaz IAttack implementada por todos los Items que contengan un valor de ataque.
-    public class IAttack
+    public interface IAttack
     {
         int AttackValue
         {

--- a/src/Library/Items/IDefense.cs
+++ b/src/Library/Items/IDefense.cs
@@ -1,6 +1,6 @@
 namespace RoleplayGame
 {
-    public interface IDefensa
+    public interface IDefense
     {
         int DefenseValue{get;}
     }

--- a/src/Library/Items/Staff.cs
+++ b/src/Library/Items/Staff.cs
@@ -1,7 +1,7 @@
 namespace RoleplayGame
 {
 
-    public class Staff :IDefensa, IAttack
+    public class Staff :IDefense, IAttack
 
     {
         public int AttackValue 


### PR DESCRIPTION
Sólo cambié el nombre de la interfaz IDefensa por IDefense en todos lados porque me di cuenta de que está todo en inglés y es la única interfaz que estaba en español. Para que quede todo igual